### PR TITLE
Remove New Jersey cutscene check before starting THUG2 runs

### DIFF
--- a/THUG2.asl
+++ b/THUG2.asl
@@ -38,7 +38,7 @@ startup
 start
 {
 	// Story Mode
-	if (current.currentLevel == "BO")
+	if (old.currentLevel == "TR" && current.currentLevel == "BO")
 	{
 		return true;
 	}

--- a/THUG2.asl
+++ b/THUG2.asl
@@ -38,7 +38,7 @@ startup
 start
 {
 	// Story Mode
-	if (current.currentLevel == "BO" && current.lastCutscene == "TR_1C")
+	if (current.currentLevel == "BO")
 	{
 		return true;
 	}


### PR DESCRIPTION
Hey, this is a small quality of life fix for the THUG2 autosplitter.

Most people nowadays will start the run by loading a save file with catbag for Bam Margera.

Loading this save file skips the training / new jersey cutscene, therefore the `current.lastCutscene == "TR_1C"` check fails and the timer never starts when the run begins.

Some people are working around it by manually starting the timer and then undoing the split triggered by the first level change, so I figured it would be easiest just to remove the check.

I've done it on my own machine, but livesplit keeps redownloading the version from this repo. Not sure if there's a way to switch that off.

No worries if you aren't accepting changes. Take it easy.